### PR TITLE
Enabling trigger bypass without deploying code

### DIFF
--- a/src/classes/TriggerHandler.cls
+++ b/src/classes/TriggerHandler.cls
@@ -95,6 +95,10 @@ public virtual class TriggerHandler {
     if(TriggerHandler.bypassedHandlers.contains(getHandlerName())) {
       return false;
     }
+    List<BypassTrigger__c> settings = BypassTrigger__c.getall().values();
+    for (BypassTrigger__c stg : settings)
+        if (stg.Name == getHandlerName() && stg.Bypass__c == true)
+          return false;
     return true;
   }
 


### PR DESCRIPTION
This change will require adding a new Custom Setting (List type) called
BypassTrigger__c, with one custom field: Bypass__c of type CheckBox.
Thus creating a custom setting record with the name exactly
corresponding to the trigger handler class name and setting it’s
Bypass__c field to True will effectively disable the trigger handler
allowing e.g. before a data load.