### PR TITLE
Added methods to bypass/clear bypass for many handlers at once.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sfdc-trigger-framework",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A minimal trigger framework for your Salesforce Apex Triggers",
   "main": "index.js",
   "scripts": {

--- a/src/classes/TriggerHandler.cls
+++ b/src/classes/TriggerHandler.cls
@@ -3,6 +3,8 @@ public virtual class TriggerHandler {
   // static map of handlername, times run() was invoked
   private static Map<String, LoopCount> loopCountMap;
   private static Set<String> bypassedHandlers;
+  @testVisible private static Boolean globalBypass;
+  @testVisible private static Boolean showLimits;
 
   // the current context of the trigger, overridable in tests
   @TestVisible
@@ -16,6 +18,8 @@ public virtual class TriggerHandler {
   static {
     loopCountMap = new Map<String, LoopCount>();
     bypassedHandlers = new Set<String>();
+    globalBypass = false;
+    showLimits = false;
   }
   
   // constructor
@@ -50,6 +54,15 @@ public virtual class TriggerHandler {
     } else if(this.context == TriggerContext.AFTER_UNDELETE) {
       this.afterUndelete();
     }
+
+    if (showLimits) {
+      System.debug(LoggingLevel.DEBUG, String.format('{0} on {1} ({2}/{3})', new List<String>{
+        this.context+'',
+        getHandlerName(),
+        Limits.getQueries()+'',
+        Limits.getLimitQueries()+''
+      }));
+    }
   }
 
   public void setMaxLoopCount(Integer max) {
@@ -79,6 +92,10 @@ public virtual class TriggerHandler {
     }
   }
 
+  public static void bypassAll() {
+    globalBypass = true;
+  }
+
   public static void clearBypass(String handlerName) {
     TriggerHandler.bypassedHandlers.remove(handlerName);
   }
@@ -95,6 +112,15 @@ public virtual class TriggerHandler {
 
   public static void clearAllBypasses() {
     TriggerHandler.bypassedHandlers.clear();
+    clearGlobalBypass();
+  }
+
+  public static void clearGlobalBypass() {
+    globalBypass = false;
+  }
+
+  public static void showLimits () {
+    showLimits = true;
   }
 
   /***************************************
@@ -159,6 +185,9 @@ public virtual class TriggerHandler {
       throw new TriggerHandlerException('Trigger handler called outside of Trigger execution');
     }
     if(TriggerHandler.bypassedHandlers.contains(getHandlerName())) {
+      return false;
+    }
+    if(globalBypass) {
       return false;
     }
     return true;

--- a/src/classes/TriggerHandler.cls
+++ b/src/classes/TriggerHandler.cls
@@ -1,278 +1,284 @@
 public virtual class TriggerHandler {
 
-  // static map of handlername, times run() was invoked
-  private static Map<String, LoopCount> loopCountMap;
-  private static Set<String> bypassedHandlers;
-  @testVisible private static Boolean globalBypass;
-  @testVisible private static Boolean showLimits;
+    // static map of handlername, times run() was invoked
+    private static Map<String, LoopCount> loopCountMap;
+    private static Set<String> bypassedHandlers;
+    @TestVisible private static Boolean globalBypass;
+    @TestVisible private static Boolean showLimits;
 
-  // the current context of the trigger, overridable in tests
-  @TestVisible
-  private TriggerContext context;
+    // the current context of the trigger, overridable in tests
+    @TestVisible
+    private TriggerContext context;
 
-  // the current context of the trigger, overridable in tests
-  @TestVisible
-  private Boolean isTriggerExecuting;
+    // the current context of the trigger, overridable in tests
+    @TestVisible
+    private Boolean isTriggerExecuting;
 
-  // static initialization
-  static {
-    loopCountMap = new Map<String, LoopCount>();
-    bypassedHandlers = new Set<String>();
-    globalBypass = false;
-    showLimits = false;
-  }
-  
-  // constructor
-  public TriggerHandler() {
-    this.setTriggerContext();
-  }
-
-  /***************************************
-   * public instance methods
-   ***************************************/
-
-  // main method that will be called during execution
-  public void run() {
-
-    if(!validateRun()) return;
-
-    addToLoopCount();
-
-    // dispatch to the correct handler method
-    if(this.context == TriggerContext.BEFORE_INSERT) {
-      this.beforeInsert();
-    } else if(this.context == TriggerContext.BEFORE_UPDATE) {
-      this.beforeUpdate();
-    } else if(this.context == TriggerContext.BEFORE_DELETE) {
-      this.beforeDelete();
-    } else if(this.context == TriggerContext.AFTER_INSERT) {
-      this.afterInsert();
-    } else if(this.context == TriggerContext.AFTER_UPDATE) {
-      this.afterUpdate();
-    } else if(this.context == TriggerContext.AFTER_DELETE) {
-      this.afterDelete();
-    } else if(this.context == TriggerContext.AFTER_UNDELETE) {
-      this.afterUndelete();
+    // static initialization
+    static {
+        loopCountMap = new Map<String, LoopCount>();
+        bypassedHandlers = new Set<String>();
+        globalBypass = false;
+        showLimits = false;
     }
 
-    if (showLimits) {
-      System.debug(LoggingLevel.DEBUG, String.format('{0} on {1} ({2}/{3})', new List<String>{
-        this.context+'',
-        getHandlerName(),
-        Limits.getQueries()+'',
-        Limits.getLimitQueries()+''
-      }));
-    }
-  }
-
-  public void setMaxLoopCount(Integer max) {
-    String handlerName = getHandlerName();
-    if(!TriggerHandler.loopCountMap.containsKey(handlerName)) {
-      TriggerHandler.loopCountMap.put(handlerName, new LoopCount(max));
-    } else {
-      TriggerHandler.loopCountMap.get(handlerName).setMax(max);
-    }
-  }
-
-  public void clearMaxLoopCount() {
-    this.setMaxLoopCount(-1);
-  }
-
-  /***************************************
-   * public static methods
-   ***************************************/
-
-  public static void bypass(String handlerName) {
-    TriggerHandler.bypassedHandlers.add(handlerName);
-  }
-
-  public static void bypass(List<String> handlersNames) {
-    for (String handlerName : handlersNames) {
-      bypass(handlerName);
-    }
-  }
-
-  public static void bypassAll() {
-    globalBypass = true;
-  }
-
-  public static void clearBypass(String handlerName) {
-    TriggerHandler.bypassedHandlers.remove(handlerName);
-  }
-
-  public static void clearBypass(List<String> handlersNames) {
-    for (String handlerName : handlersNames) {
-      clearBypass(handlerName);
-    }
-  }
-
-  public static Boolean isBypassed(String handlerName) {
-    return TriggerHandler.bypassedHandlers.contains(handlerName);
-  }
-
-  public static void clearAllBypasses() {
-    TriggerHandler.bypassedHandlers.clear();
-    clearGlobalBypass();
-  }
-
-  public static void clearGlobalBypass() {
-    globalBypass = false;
-  }
-
-  public static void showLimits () {
-    showLimits = true;
-  }
-
-  /***************************************
-   * private instancemethods
-   ***************************************/
-
-  @TestVisible
-  private void setTriggerContext() {
-    this.setTriggerContext(null, false);
-  }
-
-  @TestVisible
-  private void setTriggerContext(String ctx, Boolean testMode) {
-    if(!Trigger.isExecuting && !testMode) {
-      this.isTriggerExecuting = false;
-      return;
-    } else {
-      this.isTriggerExecuting = true;
-    }
-    
-    if((Trigger.isExecuting && Trigger.isBefore && Trigger.isInsert) ||
-        (ctx != null && ctx == 'before insert')) {
-      this.context = TriggerContext.BEFORE_INSERT;
-    } else if((Trigger.isExecuting && Trigger.isBefore && Trigger.isUpdate) ||
-        (ctx != null && ctx == 'before update')){
-      this.context = TriggerContext.BEFORE_UPDATE;
-    } else if((Trigger.isExecuting && Trigger.isBefore && Trigger.isDelete) ||
-        (ctx != null && ctx == 'before delete')) {
-      this.context = TriggerContext.BEFORE_DELETE;
-    } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isInsert) ||
-        (ctx != null && ctx == 'after insert')) {
-      this.context = TriggerContext.AFTER_INSERT;
-    } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isUpdate) ||
-        (ctx != null && ctx == 'after update')) {
-      this.context = TriggerContext.AFTER_UPDATE;
-    } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isDelete) ||
-        (ctx != null && ctx == 'after delete')) {
-      this.context = TriggerContext.AFTER_DELETE;
-    } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isUndelete) ||
-        (ctx != null && ctx == 'after undelete')) {
-      this.context = TriggerContext.AFTER_UNDELETE;
-    }
-  }
-
-  // increment the loop count
-  @TestVisible
-  private void addToLoopCount() {
-    String handlerName = getHandlerName();
-    if(TriggerHandler.loopCountMap.containsKey(handlerName)) {
-      Boolean exceeded = TriggerHandler.loopCountMap.get(handlerName).increment();
-      if(exceeded) {
-        Integer max = TriggerHandler.loopCountMap.get(handlerName).max;
-        throw new TriggerHandlerException('Maximum loop count of ' + String.valueOf(max) + ' reached in ' + handlerName);
-      }
-    }
-  }
-
-  // make sure this trigger should continue to run
-  @TestVisible
-  private Boolean validateRun() {
-    if(!this.isTriggerExecuting || this.context == null) {
-      throw new TriggerHandlerException('Trigger handler called outside of Trigger execution');
-    }
-    if(TriggerHandler.bypassedHandlers.contains(getHandlerName())) {
-      return false;
-    }
-    if(globalBypass) {
-      return false;
-    }
-    return true;
-  }
-
-  @TestVisible
-  private String getHandlerName() {
-    return String.valueOf(this).substring(0,String.valueOf(this).indexOf(':'));
-  }
-
-  /***************************************
-   * context methods
-   ***************************************/
-
-  // context-specific methods for override
-  @TestVisible
-  protected virtual void beforeInsert(){}
-  @TestVisible
-  protected virtual void beforeUpdate(){}
-  @TestVisible
-  protected virtual void beforeDelete(){}
-  @TestVisible
-  protected virtual void afterInsert(){}
-  @TestVisible
-  protected virtual void afterUpdate(){}
-  @TestVisible
-  protected virtual void afterDelete(){}
-  @TestVisible
-  protected virtual void afterUndelete(){}
-
-  /***************************************
-   * inner classes
-   ***************************************/
-
-  // inner class for managing the loop count per handler
-  @TestVisible
-  private class LoopCount {
-    private Integer max;
-    private Integer count;
-
-    public LoopCount() {
-      this.max = 5;
-      this.count = 0;
+    // constructor
+    public TriggerHandler() {
+        this.setTriggerContext();
     }
 
-    public LoopCount(Integer max) {
-      this.max = max;
-      this.count = 0;
+    /***************************************
+     * public instance methods
+     ***************************************/
+
+    // main method that will be called during execution
+    public void run () {
+
+        if (!validateRun()) return;
+
+        addToLoopCount();
+
+        // dispatch to the correct handler method
+        if (this.context == TriggerContext.BEFORE_INSERT) {
+            this.beforeInsert();
+        } else if (this.context == TriggerContext.BEFORE_UPDATE) {
+            this.beforeUpdate();
+        } else if (this.context == TriggerContext.BEFORE_DELETE) {
+            this.beforeDelete();
+        } else if (this.context == TriggerContext.AFTER_INSERT) {
+            this.afterInsert();
+        } else if (this.context == TriggerContext.AFTER_UPDATE) {
+            this.afterUpdate();
+        } else if (this.context == TriggerContext.AFTER_DELETE) {
+            this.afterDelete();
+        } else if (this.context == TriggerContext.AFTER_UNDELETE) {
+            this.afterUndelete();
+        }
+
+        if (showLimits) {
+            System.debug(LoggingLevel.DEBUG, String.format('{0} on {1} ({2}/{3})', new List<String>{
+                this.context+'',
+                getHandlerName(),
+                Limits.getQueries()+'',
+                Limits.getLimitQueries()+''
+            }));
+        }
     }
 
-    public Boolean increment() {
-      this.count++;
-      return this.exceeded();
+    public void setMaxLoopCount (Integer max) {
+        String handlerName = getHandlerName();
+        if (!TriggerHandler.loopCountMap.containsKey(handlerName)) {
+            TriggerHandler.loopCountMap.put(handlerName, new LoopCount(max));
+        } else {
+            TriggerHandler.loopCountMap.get(handlerName).setMax(max);
+        }
     }
 
-    public Boolean exceeded() {
-      if(this.max < 0) return false;
-      if(this.count > this.max) {
+    public void clearMaxLoopCount () {
+        this.setMaxLoopCount(-1);
+    }
+
+    /***************************************
+     * public static methods
+     ***************************************/
+
+    public static void bypass (String handlerName) {
+        bypassedHandlers.add(handlerName);
+    }
+
+    public static void bypass (List<String> handlersNames) {
+        for (String handlerName : handlersNames) {
+            bypass(handlerName);
+        }
+    }
+
+    public static void bypass (Type classType) {
+        bypass(classType.getName());
+    }
+
+    public static void bypassAll () {
+        globalBypass = true;
+    }
+
+    public static void clearBypass (String handlerName) {
+        bypassedHandlers.remove(handlerName);
+    }
+
+    public static void clearBypass (Type classType) {
+        clearBypass(classType.getName());
+    }
+
+    public static void clearBypass (List<String> handlersNames) {
+        for (String handlerName : handlersNames) {
+            clearBypass(handlerName);
+        }
+    }
+
+    public static void clearGlobalBypass () {
+        globalBypass = false;
+    }
+
+    public static Boolean isBypassed (String handlerName) {
+        return bypassedHandlers.contains(handlerName);
+    }
+
+    public static Boolean isBypassed (Type classType) {
+        return bypassedHandlers.contains(classType.getName());
+    }
+
+    public static void showLimits () {
+        showLimits = true;
+    }
+
+    /***************************************
+     * private instancemethods
+     ***************************************/
+
+    @TestVisible
+    private void setTriggerContext () {
+        this.setTriggerContext(null, false);
+    }
+
+    @TestVisible
+    private void setTriggerContext (String ctx, Boolean testMode) {
+        if (!Trigger.isExecuting && !testMode) {
+            this.isTriggerExecuting = false;
+            return;
+        } else {
+            this.isTriggerExecuting = true;
+        }
+
+        if ((Trigger.isExecuting && Trigger.isBefore && Trigger.isInsert) ||
+            (ctx != null && ctx == 'before insert')) {
+            this.context = TriggerContext.BEFORE_INSERT;
+        } else if((Trigger.isExecuting && Trigger.isBefore && Trigger.isUpdate) ||
+            (ctx != null && ctx == 'before update')){
+            this.context = TriggerContext.BEFORE_UPDATE;
+        } else if((Trigger.isExecuting && Trigger.isBefore && Trigger.isDelete) ||
+            (ctx != null && ctx == 'before delete')) {
+            this.context = TriggerContext.BEFORE_DELETE;
+        } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isInsert) ||
+            (ctx != null && ctx == 'after insert')) {
+            this.context = TriggerContext.AFTER_INSERT;
+        } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isUpdate) ||
+            (ctx != null && ctx == 'after update')) {
+            this.context = TriggerContext.AFTER_UPDATE;
+        } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isDelete) ||
+            (ctx != null && ctx == 'after delete')) {
+            this.context = TriggerContext.AFTER_DELETE;
+        } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isUndelete) ||
+            (ctx != null && ctx == 'after undelete')) {
+            this.context = TriggerContext.AFTER_UNDELETE;
+        }
+    }
+
+    // increment the loop count
+    @TestVisible
+    private void addToLoopCount () {
+        String handlerName = getHandlerName();
+        if(TriggerHandler.loopCountMap.containsKey(handlerName)) {
+            Boolean exceeded = TriggerHandler.loopCountMap.get(handlerName).increment();
+            if(exceeded) {
+                Integer max = TriggerHandler.loopCountMap.get(handlerName).max;
+                throw new TriggerHandlerException('Maximum loop count of ' + String.valueOf(max) + ' reached in ' + handlerName);
+            }
+        }
+    }
+
+    // make sure this trigger should continue to run
+    @TestVisible
+    private Boolean validateRun () {
+        if (!this.isTriggerExecuting || this.context == null) {
+            throw new TriggerHandlerException('Trigger handler called outside of Trigger execution');
+        }
+        if (globalBypass) {
+            return false;
+        }
+        if (TriggerHandler.bypassedHandlers.contains(getHandlerName())) {
+            return false;
+        }
         return true;
-      }
-      return false;
     }
 
-    public Integer getMax() {
-      return this.max;
+    @TestVisible
+    private String getHandlerName () {
+        return String.valueOf(this).substring(0,String.valueOf(this).indexOf(':'));
     }
 
-    public Integer getCount() {
-      return this.count;
+    /***************************************
+     * context methods
+     ***************************************/
+
+    // context-specific methods for override
+    @TestVisible
+    protected virtual void beforeInsert () {}
+    @TestVisible
+    protected virtual void beforeUpdate () {}
+    @TestVisible
+    protected virtual void beforeDelete () {}
+    @TestVisible
+    protected virtual void afterInsert () {}
+    @TestVisible
+    protected virtual void afterUpdate () {}
+    @TestVisible
+    protected virtual void afterDelete () {}
+    @TestVisible
+    protected virtual void afterUndelete () {}
+
+    /***************************************
+     * inner classes
+     ***************************************/
+
+    // inner class for managing the loop count per handler
+    @TestVisible
+    private class LoopCount {
+        private Integer max;
+        private Integer count;
+
+        public LoopCount() {
+            this.max = 5;
+            this.count = 0;
+        }
+
+        public LoopCount(Integer max) {
+            this.max = max;
+            this.count = 0;
+        }
+
+        public Boolean increment() {
+            this.count++;
+            return this.exceeded();
+        }
+
+        public Boolean exceeded() {
+            if (this.max < 0) return false;
+            if (this.count > this.max) {
+                return true;
+            }
+            return false;
+        }
+
+        public Integer getMax() {
+            return this.max;
+        }
+
+        public Integer getCount() {
+            return this.count;
+        }
+
+        public void setMax(Integer max) {
+            this.max = max;
+        }
     }
 
-    public void setMax(Integer max) {
-      this.max = max;
+    // possible trigger contexts
+    @TestVisible
+    private enum TriggerContext {
+        BEFORE_INSERT, BEFORE_UPDATE, BEFORE_DELETE,
+        AFTER_INSERT, AFTER_UPDATE, AFTER_DELETE,
+        AFTER_UNDELETE
     }
-  }
 
-  // possible trigger contexts
-  @TestVisible
-  private enum TriggerContext {
-    BEFORE_INSERT, BEFORE_UPDATE, BEFORE_DELETE,
-    AFTER_INSERT, AFTER_UPDATE, AFTER_DELETE,
-    AFTER_UNDELETE
-  }
-
-  // exception class
-  public class TriggerHandlerException extends Exception {}
-
+    // exception class
+    public class TriggerHandlerException extends Exception {}
 }

--- a/src/classes/TriggerHandler.cls
+++ b/src/classes/TriggerHandler.cls
@@ -87,9 +87,7 @@ public virtual class TriggerHandler {
     }
 
     public static void bypass (List<String> handlersNames) {
-        for (String handlerName : handlersNames) {
-            bypass(handlerName);
-        }
+        bypassedHandlers.addAll(handlersNames);
     }
 
     public static void bypass (Type handlerType) {
@@ -109,9 +107,7 @@ public virtual class TriggerHandler {
     }
 
     public static void clearBypass (List<String> handlersNames) {
-        for (String handlerName : handlersNames) {
-            clearBypass(handlerName);
-        }
+        bypassedHandlers.removeAll(handlersNames);
     }
 
     public static void clearGlobalBypass () {

--- a/src/classes/TriggerHandler.cls
+++ b/src/classes/TriggerHandler.cls
@@ -92,8 +92,8 @@ public virtual class TriggerHandler {
         }
     }
 
-    public static void bypass (Type classType) {
-        bypass(classType.getName());
+    public static void bypass (Type handlerType) {
+        bypass(handlerType.getName());
     }
 
     public static void bypassAll () {
@@ -104,8 +104,8 @@ public virtual class TriggerHandler {
         bypassedHandlers.remove(handlerName);
     }
 
-    public static void clearBypass (Type classType) {
-        clearBypass(classType.getName());
+    public static void clearBypass (Type handlerType) {
+        clearBypass(handlerType.getName());
     }
 
     public static void clearBypass (List<String> handlersNames) {
@@ -122,12 +122,19 @@ public virtual class TriggerHandler {
         return bypassedHandlers.contains(handlerName);
     }
 
-    public static Boolean isBypassed (Type classType) {
-        return bypassedHandlers.contains(classType.getName());
+    public static Boolean isBypassed (Type handlerType) {
+        return bypassedHandlers.contains(handlerType.getName());
     }
 
     public static void showLimits () {
         showLimits = true;
+    }
+
+    public static Integer getLoopCount (String handlerName) {
+        if (TriggerHandler.loopCountMap.containsKey(handlerName)) {
+            return TriggerHandler.loopCountMap.get(handlerName).getCount();
+        }
+        return 0;
     }
 
     /***************************************
@@ -151,22 +158,22 @@ public virtual class TriggerHandler {
         if ((Trigger.isExecuting && Trigger.isBefore && Trigger.isInsert) ||
             (ctx != null && ctx == 'before insert')) {
             this.context = TriggerContext.BEFORE_INSERT;
-        } else if((Trigger.isExecuting && Trigger.isBefore && Trigger.isUpdate) ||
+        } else if ((Trigger.isExecuting && Trigger.isBefore && Trigger.isUpdate) ||
             (ctx != null && ctx == 'before update')){
             this.context = TriggerContext.BEFORE_UPDATE;
-        } else if((Trigger.isExecuting && Trigger.isBefore && Trigger.isDelete) ||
+        } else if ((Trigger.isExecuting && Trigger.isBefore && Trigger.isDelete) ||
             (ctx != null && ctx == 'before delete')) {
             this.context = TriggerContext.BEFORE_DELETE;
-        } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isInsert) ||
+        } else if ((Trigger.isExecuting && Trigger.isAfter && Trigger.isInsert) ||
             (ctx != null && ctx == 'after insert')) {
             this.context = TriggerContext.AFTER_INSERT;
-        } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isUpdate) ||
+        } else if ((Trigger.isExecuting && Trigger.isAfter && Trigger.isUpdate) ||
             (ctx != null && ctx == 'after update')) {
             this.context = TriggerContext.AFTER_UPDATE;
-        } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isDelete) ||
+        } else if ((Trigger.isExecuting && Trigger.isAfter && Trigger.isDelete) ||
             (ctx != null && ctx == 'after delete')) {
             this.context = TriggerContext.AFTER_DELETE;
-        } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isUndelete) ||
+        } else if ((Trigger.isExecuting && Trigger.isAfter && Trigger.isUndelete) ||
             (ctx != null && ctx == 'after undelete')) {
             this.context = TriggerContext.AFTER_UNDELETE;
         }
@@ -176,9 +183,9 @@ public virtual class TriggerHandler {
     @TestVisible
     private void addToLoopCount () {
         String handlerName = getHandlerName();
-        if(TriggerHandler.loopCountMap.containsKey(handlerName)) {
+        if (TriggerHandler.loopCountMap.containsKey(handlerName)) {
             Boolean exceeded = TriggerHandler.loopCountMap.get(handlerName).increment();
-            if(exceeded) {
+            if (exceeded) {
                 Integer max = TriggerHandler.loopCountMap.get(handlerName).max;
                 throw new TriggerHandlerException('Maximum loop count of ' + String.valueOf(max) + ' reached in ' + handlerName);
             }
@@ -202,7 +209,7 @@ public virtual class TriggerHandler {
 
     @TestVisible
     private String getHandlerName () {
-        return String.valueOf(this).substring(0,String.valueOf(this).indexOf(':'));
+        return String.valueOf(this).substring(0, String.valueOf(this).indexOf(':'));
     }
 
     /***************************************

--- a/src/classes/TriggerHandler.cls
+++ b/src/classes/TriggerHandler.cls
@@ -50,8 +50,6 @@ public virtual class TriggerHandler {
     } else if(this.context == TriggerContext.AFTER_UNDELETE) {
       this.afterUndelete();
     }
-
-    System.debug(LoggingLevel.INFO, this.context + '(' + getHandlerName() + ')');
   }
 
   public void setMaxLoopCount(Integer max) {

--- a/src/classes/TriggerHandler.cls
+++ b/src/classes/TriggerHandler.cls
@@ -51,6 +51,7 @@ public virtual class TriggerHandler {
       this.afterUndelete();
     }
 
+    System.debug(LoggingLevel.INFO, this.context + '(' + getHandlerName() + ')');
   }
 
   public void setMaxLoopCount(Integer max) {
@@ -74,8 +75,20 @@ public virtual class TriggerHandler {
     TriggerHandler.bypassedHandlers.add(handlerName);
   }
 
+  public static void bypass(List<String> handlersNames) {
+    for (String handlerName : handlersNames) {
+      bypass(handlerName);
+    }
+  }
+
   public static void clearBypass(String handlerName) {
     TriggerHandler.bypassedHandlers.remove(handlerName);
+  }
+
+  public static void clearBypass(List<String> handlersNames) {
+    for (String handlerName : handlersNames) {
+      clearBypass(handlerName);
+    }
   }
 
   public static Boolean isBypassed(String handlerName) {

--- a/src/classes/TriggerHandler_Test.cls
+++ b/src/classes/TriggerHandler_Test.cls
@@ -118,12 +118,28 @@ private class TriggerHandler_Test {
     System.assertEquals(true, TriggerHandler.isBypassed('TestHandler'), 'test handler should be bypassed');
     resetTest();
 
+    // global bypass test
+    TriggerHandler.bypassAll();
+    handler.run();
+    System.assertEquals(null, lastMethodCalled, 'last method should be null when bypassed');
+    System.assertEquals(true, TriggerHandler.globalBypass, 'global bypass should be active');
+    TriggerHandler.clearGlobalBypass();
+    System.assertEquals(false, TriggerHandler.globalBypass, 'global bypass should not be active');
+    resetTest();
+
     // clear all bypasses and run handler
     TriggerHandler.clearAllBypasses();
     handler.run();
     System.assertEquals('afterUpdate', lastMethodCalled, 'last method called should be afterUpdate');
     System.assertEquals(false, TriggerHandler.isBypassed('TestHandler'), 'test handler should be bypassed');
     resetTest();
+  }
+
+  @isTest
+  static void testShowLimits () {
+    // not really possible to test this, I believe, but it is nice to have the coverage.
+    TriggerHandler.showLimits();
+    System.assertEquals(true, TriggerHandler.showLimits);
   }
 
   // instance method tests
@@ -284,5 +300,5 @@ private class TriggerHandler_Test {
     }
 
   }
-	
+  
 }

--- a/src/classes/TriggerHandler_Test.cls
+++ b/src/classes/TriggerHandler_Test.cls
@@ -1,304 +1,307 @@
-@isTest
+@IsTest
 private class TriggerHandler_Test {
 
-  private static final String TRIGGER_CONTEXT_ERROR = 'Trigger handler called outside of Trigger execution';
+    private static final String TRIGGER_CONTEXT_ERROR = 'Trigger handler called outside of Trigger execution';
 
-  private static String lastMethodCalled;
+    private static String lastMethodCalled;
 
-  private static TriggerHandler_Test.TestHandler handler;
+    private static TriggerHandler_Test.TestHandler handler;
 
-  static {
-    handler = new TriggerHandler_Test.TestHandler();
-    // override its internal trigger detection
-    handler.isTriggerExecuting = true;
-  }
-
-  /***************************************
-   * unit tests
-   ***************************************/
-
-  // contexts tests
-
-  @isTest
-  static void testBeforeInsert() {
-    beforeInsertMode();
-    handler.run();
-    System.assertEquals('beforeInsert', lastMethodCalled, 'last method should be beforeInsert');
-  }
-
-  @isTest
-  static void testBeforeUpdate() {
-    beforeUpdateMode();
-    handler.run();
-    System.assertEquals('beforeUpdate', lastMethodCalled, 'last method should be beforeUpdate');
-  }
-
-  @isTest
-  static void testBeforeDelete() {
-    beforeDeleteMode();
-    handler.run();
-    System.assertEquals('beforeDelete', lastMethodCalled, 'last method should be beforeDelete');
-  }
-
-  @isTest
-  static void testAfterInsert() {
-    afterInsertMode();
-    handler.run();
-    System.assertEquals('afterInsert', lastMethodCalled, 'last method should be afterInsert');
-  }
-
-  @isTest
-  static void testAfterUpdate() {
-    afterUpdateMode();
-    handler.run();
-    System.assertEquals('afterUpdate', lastMethodCalled, 'last method should be afterUpdate');
-  }
-
-  @isTest
-  static void testAfterDelete() {
-    afterDeleteMode();
-    handler.run();
-    System.assertEquals('afterDelete', lastMethodCalled, 'last method should be afterDelete');
-  }
-
-  @isTest
-  static void testAfterUndelete() {
-    afterUndeleteMode();
-    handler.run();
-    System.assertEquals('afterUndelete', lastMethodCalled, 'last method should be afterUndelete');
-  }
-
-  @isTest 
-  static void testNonTriggerContext() {
-    try{
-      handler.run();
-      System.assert(false, 'the handler ran but should have thrown');
-    } catch(TriggerHandler.TriggerHandlerException te) {
-      System.assertEquals(TRIGGER_CONTEXT_ERROR, te.getMessage(), 'the exception message should match');
-    } catch(Exception e) {
-      System.assert(false, 'the exception thrown was not expected: ' + e.getTypeName() + ': ' + e.getMessage());
-    }
-  }
-
-  // test bypass api
-
-  @isTest
-  static void testBypassAPI() {
-    afterUpdateMode();
-
-    // test a bypass and run handler
-    TriggerHandler.bypass('TestHandler');
-    handler.run();
-    System.assertEquals(null, lastMethodCalled, 'last method should be null when bypassed');
-    System.assertEquals(true, TriggerHandler.isBypassed('TestHandler'), 'test handler should be bypassed');
-    resetTest();
-
-    // test multiple bypasses and bypass clear
-    TriggerHandler.bypass(new List<String>{'FirstHandler', 'SecondHandler'});
-    handler.run();
-    System.assertEquals(null, lastMethodCalled, 'last method should be null when bypassed');
-    System.assertEquals(true, TriggerHandler.isBypassed('FirstHandler'), 'first test handler should be bypassed');
-    System.assertEquals(true, TriggerHandler.isBypassed('SecondHandler'), 'second test handler should be bypassed');
-    TriggerHandler.clearBypass(new List<String>{'FirstHandler', 'SecondHandler'});
-    System.assertEquals(false, TriggerHandler.isBypassed('FirstHandler'), 'first test handler should not be bypassed');
-    System.assertEquals(false, TriggerHandler.isBypassed('SecondHandler'), 'second test handler should not be bypassed');
-    resetTest();
-
-    // clear that bypass and run handler
-    TriggerHandler.clearBypass('TestHandler');
-    handler.run();
-    System.assertEquals('afterUpdate', lastMethodCalled, 'last method called should be afterUpdate');
-    System.assertEquals(false, TriggerHandler.isBypassed('TestHandler'), 'test handler should be bypassed');
-    resetTest();
-
-    // test a re-bypass and run handler
-    TriggerHandler.bypass('TestHandler');
-    handler.run();
-    System.assertEquals(null, lastMethodCalled, 'last method should be null when bypassed');
-    System.assertEquals(true, TriggerHandler.isBypassed('TestHandler'), 'test handler should be bypassed');
-    resetTest();
-
-    // global bypass test
-    TriggerHandler.bypassAll();
-    handler.run();
-    System.assertEquals(null, lastMethodCalled, 'last method should be null when bypassed');
-    System.assertEquals(true, TriggerHandler.globalBypass, 'global bypass should be active');
-    TriggerHandler.clearGlobalBypass();
-    System.assertEquals(false, TriggerHandler.globalBypass, 'global bypass should not be active');
-    resetTest();
-
-    // clear all bypasses and run handler
-    TriggerHandler.clearAllBypasses();
-    handler.run();
-    System.assertEquals('afterUpdate', lastMethodCalled, 'last method called should be afterUpdate');
-    System.assertEquals(false, TriggerHandler.isBypassed('TestHandler'), 'test handler should be bypassed');
-    resetTest();
-  }
-
-  @isTest
-  static void testShowLimits () {
-    // not really possible to test this, I believe, but it is nice to have the coverage.
-    TriggerHandler.showLimits();
-    System.assertEquals(true, TriggerHandler.showLimits);
-  }
-
-  // instance method tests
-
-  @isTest
-  static void testLoopCount() {
-    beforeInsertMode();
-    
-    // set the max loops to 2
-    handler.setMaxLoopCount(2);
-
-    // run the handler twice
-    handler.run();
-    handler.run();
-
-    // clear the tests
-    resetTest();
-
-    try {
-      // try running it. This should exceed the limit.
-      handler.run();
-      System.assert(false, 'the handler should throw on the 3rd run when maxloopcount is 3');
-    } catch(TriggerHandler.TriggerHandlerException te) {
-      // we're expecting to get here
-      System.assertEquals(null, lastMethodCalled, 'last method should be null');
-    } catch(Exception e) {  
-      System.assert(false, 'the exception thrown was not expected: ' + e.getTypeName() + ': ' + e.getMessage());
+    static {
+        handler = new TriggerHandler_Test.TestHandler();
+        // override its internal trigger detection
+        handler.isTriggerExecuting = true;
     }
 
-    // clear the tests
-    resetTest();
+    /***************************************
+     * unit tests
+     ***************************************/
 
-    // now clear the loop count
-    handler.clearMaxLoopCount();
+    // contexts tests
 
-    try {
-      // re-run the handler. We shouldn't throw now.
-      handler.run();
-      System.assertEquals('beforeInsert', lastMethodCalled, 'last method should be beforeInsert');
-    } catch(TriggerHandler.TriggerHandlerException te) {
-      System.assert(false, 'running the handler after clearing the loop count should not throw');
-    } catch(Exception e) {  
-      System.assert(false, 'the exception thrown was not expected: ' + e.getTypeName() + ': ' + e.getMessage());
-    }
-  }
-
-  @isTest
-  static void testLoopCountClass() {
-    TriggerHandler.LoopCount lc = new TriggerHandler.LoopCount();
-    System.assertEquals(5, lc.getMax(), 'max should be five on init');
-    System.assertEquals(0, lc.getCount(), 'count should be zero on init');
-
-    lc.increment();
-    System.assertEquals(1, lc.getCount(), 'count should be 1');
-    System.assertEquals(false, lc.exceeded(), 'should not be exceeded with count of 1');
-
-    lc.increment();
-    lc.increment();
-    lc.increment();
-    lc.increment();
-    System.assertEquals(5, lc.getCount(), 'count should be 5');
-    System.assertEquals(false, lc.exceeded(), 'should not be exceeded with count of 5');
-
-    lc.increment();
-    System.assertEquals(6, lc.getCount(), 'count should be 6');
-    System.assertEquals(true, lc.exceeded(), 'should not be exceeded with count of 6');
-  }
-
-  // private method tests
-
-  @isTest 
-  static void testGetHandlerName() {
-    System.assertEquals('TestHandler', handler.getHandlerName(), 'handler name should match class name');
-  }
-
-  // test virtual methods
-  
-  @isTest
-  static void testVirtualMethods() {
-    TriggerHandler h = new TriggerHandler();
-    h.beforeInsert();
-    h.beforeUpdate();
-    h.beforeDelete();
-    h.afterInsert();
-    h.afterUpdate();
-    h.afterDelete();
-    h.afterUndelete();
-  }
-
-  /***************************************
-   * testing utilities
-   ***************************************/
-
-  private static void resetTest() {
-    lastMethodCalled = null;
-  }
-
-  // modes for testing
-
-  private static void beforeInsertMode() {
-    handler.setTriggerContext('before insert', true);
-  }
-
-  private static void beforeUpdateMode() {
-    handler.setTriggerContext('before update', true);
-  }
-
-  private static void beforeDeleteMode() {
-    handler.setTriggerContext('before delete', true);
-  }
-
-  private static void afterInsertMode() {
-    handler.setTriggerContext('after insert', true);
-  }
-
-  private static void afterUpdateMode() {
-    handler.setTriggerContext('after update', true);
-  }
-
-  private static void afterDeleteMode() {
-    handler.setTriggerContext('after delete', true);
-  }
-
-  private static void afterUndeleteMode() {
-    handler.setTriggerContext('after undelete', true);
-  }
-
-  // test implementation of the TriggerHandler
-
-  private class TestHandler extends TriggerHandler {
-
-    public override void beforeInsert() {
-      TriggerHandler_Test.lastMethodCalled = 'beforeInsert';
+    @IsTest
+    static void testBeforeInsert() {
+        beforeInsertMode();
+        handler.run();
+        System.assertEquals('beforeInsert', lastMethodCalled, 'last method should be beforeInsert');
     }
 
-    public override void  beforeUpdate() {
-      TriggerHandler_Test.lastMethodCalled = 'beforeUpdate';
+    @IsTest
+    static void testBeforeUpdate() {
+        beforeUpdateMode();
+        handler.run();
+        System.assertEquals('beforeUpdate', lastMethodCalled, 'last method should be beforeUpdate');
     }
 
-    public override void beforeDelete() {
-      TriggerHandler_Test.lastMethodCalled = 'beforeDelete';
+    @IsTest
+    static void testBeforeDelete() {
+        beforeDeleteMode();
+        handler.run();
+        System.assertEquals('beforeDelete', lastMethodCalled, 'last method should be beforeDelete');
     }
 
-    public override void afterInsert() {
-      TriggerHandler_Test.lastMethodCalled = 'afterInsert';
+    @IsTest
+    static void testAfterInsert() {
+        afterInsertMode();
+        handler.run();
+        System.assertEquals('afterInsert', lastMethodCalled, 'last method should be afterInsert');
     }
 
-    public override void afterUpdate() {
-      TriggerHandler_Test.lastMethodCalled = 'afterUpdate';
+    @IsTest
+    static void testAfterUpdate() {
+        afterUpdateMode();
+        handler.run();
+        System.assertEquals('afterUpdate', lastMethodCalled, 'last method should be afterUpdate');
     }
 
-    public override void afterDelete() {
-      TriggerHandler_Test.lastMethodCalled = 'afterDelete';
+    @IsTest
+    static void testAfterDelete() {
+        afterDeleteMode();
+        handler.run();
+        System.assertEquals('afterDelete', lastMethodCalled, 'last method should be afterDelete');
     }
 
-    public override void afterUndelete() {
-      TriggerHandler_Test.lastMethodCalled = 'afterUndelete';
+    @IsTest
+    static void testAfterUndelete() {
+        afterUndeleteMode();
+        handler.run();
+        System.assertEquals('afterUndelete', lastMethodCalled, 'last method should be afterUndelete');
     }
 
-  }
-  
+    @IsTest
+    static void testNonTriggerContext() {
+        try {
+            handler.run();
+            System.assert(false, 'the handler ran but should have thrown');
+        } catch (TriggerHandler.TriggerHandlerException te) {
+            System.assertEquals(TRIGGER_CONTEXT_ERROR, te.getMessage(), 'the exception message should match');
+        } catch (Exception e) {
+            System.assert(false, 'the exception thrown was not expected: ' + e.getTypeName() + ': ' + e.getMessage());
+        }
+    }
+
+    // test bypass api
+
+    @IsTest
+    static void testBypassAPI() {
+        afterUpdateMode();
+
+        // test a bypass and run handler
+        TriggerHandler.bypass('TestHandler');
+        handler.run();
+        System.assertEquals(null, lastMethodCalled, 'last method should be null when bypassed');
+        System.assertEquals(true, TriggerHandler.isBypassed('TestHandler'), 'test handler should be bypassed');
+        resetTest();
+
+        // test multiple bypasses and bypass clear
+        TriggerHandler.bypass(new List<String>{'FirstHandler', 'SecondHandler'});
+        handler.run();
+        System.assertEquals(null, lastMethodCalled, 'last method should be null when bypassed');
+        System.assertEquals(true, TriggerHandler.isBypassed('FirstHandler'), 'first test handler should be bypassed');
+        System.assertEquals(true, TriggerHandler.isBypassed('SecondHandler'), 'second test handler should be bypassed');
+        TriggerHandler.clearBypass(new List<String>{'FirstHandler', 'SecondHandler'});
+        System.assertEquals(false, TriggerHandler.isBypassed('FirstHandler'), 'first test handler should not be bypassed');
+        System.assertEquals(false, TriggerHandler.isBypassed('SecondHandler'), 'second test handler should not be bypassed');
+        resetTest();
+
+        // clear that bypass and run handler
+        TriggerHandler.clearBypass('TestHandler');
+        handler.run();
+        System.assertEquals('afterUpdate', lastMethodCalled, 'last method called should be afterUpdate');
+        System.assertEquals(false, TriggerHandler.isBypassed('TestHandler'), 'test handler should be bypassed');
+        resetTest();
+
+        // test a re-bypass and run handler
+        TriggerHandler.bypass('TestHandler');
+        handler.run();
+        System.assertEquals(null, lastMethodCalled, 'last method should be null when bypassed');
+        System.assertEquals(true, TriggerHandler.isBypassed('TestHandler'), 'test handler should be bypassed');
+        resetTest();
+
+        // global bypass test
+        TriggerHandler.bypassAll();
+        handler.run();
+        System.assertEquals(null, lastMethodCalled, 'last method should be null when bypassed');
+        System.assertEquals(true, TriggerHandler.globalBypass, 'global bypass should be active');
+        TriggerHandler.clearGlobalBypass();
+        System.assertEquals(false, TriggerHandler.globalBypass, 'global bypass should not be active');
+        resetTest();
+
+        // test bypass by type
+        // test a bypass and run handler
+        TriggerHandler.bypass(TriggerHandler_Test.class);
+        handler.run();
+        System.assertEquals(null, lastMethodCalled, 'last method should be null when bypassed');
+        System.assertEquals(true, TriggerHandler.isBypassed(TriggerHandler_Test.class), 'test handler ' +
+            'should be bypassed');
+        TriggerHandler.clearBypass(TriggerHandler_Test.class);
+        System.assertEquals(false, TriggerHandler.isBypassed(TriggerHandler_Test.class), 'test handler ' +
+            'bypass should not be active');
+        resetTest();
+    }
+
+    @IsTest
+    static void testShowLimits () {
+        // not really possible to test this, I believe, but it is nice to have the coverage.
+        TriggerHandler.showLimits();
+        System.assertEquals(true, TriggerHandler.showLimits);
+    }
+
+    // instance method tests
+
+    @IsTest
+    static void testLoopCount() {
+        beforeInsertMode();
+
+        // set the max loops to 2
+        handler.setMaxLoopCount(2);
+
+        // run the handler twice
+        handler.run();
+        handler.run();
+
+        // clear the tests
+        resetTest();
+
+        try {
+            // try running it. This should exceed the limit.
+            handler.run();
+            System.assert(false, 'the handler should throw on the 3rd run when maxloopcount is 3');
+        } catch (TriggerHandler.TriggerHandlerException te) {
+            // we're expecting to get here
+            System.assertEquals(null, lastMethodCalled, 'last method should be null');
+        } catch (Exception e) {
+            System.assert(false, 'the exception thrown was not expected: ' + e.getTypeName() + ': ' + e.getMessage());
+        }
+
+        // clear the tests
+        resetTest();
+
+        // now clear the loop count
+        handler.clearMaxLoopCount();
+
+        try {
+            // re-run the handler. We shouldn't throw now.
+            handler.run();
+            System.assertEquals('beforeInsert', lastMethodCalled, 'last method should be beforeInsert');
+        } catch (TriggerHandler.TriggerHandlerException te) {
+            System.assert(false, 'running the handler after clearing the loop count should not throw');
+        } catch (Exception e) {
+            System.assert(false, 'the exception thrown was not expected: ' + e.getTypeName() + ': ' + e.getMessage());
+        }
+    }
+
+    @IsTest
+    static void testLoopCountClass() {
+        TriggerHandler.LoopCount lc = new TriggerHandler.LoopCount();
+        System.assertEquals(5, lc.getMax(), 'max should be five on init');
+        System.assertEquals(0, lc.getCount(), 'count should be zero on init');
+
+        lc.increment();
+        System.assertEquals(1, lc.getCount(), 'count should be 1');
+        System.assertEquals(false, lc.exceeded(), 'should not be exceeded with count of 1');
+
+        lc.increment();
+        lc.increment();
+        lc.increment();
+        lc.increment();
+        System.assertEquals(5, lc.getCount(), 'count should be 5');
+        System.assertEquals(false, lc.exceeded(), 'should not be exceeded with count of 5');
+
+        lc.increment();
+        System.assertEquals(6, lc.getCount(), 'count should be 6');
+        System.assertEquals(true, lc.exceeded(), 'should not be exceeded with count of 6');
+    }
+
+    // private method tests
+
+    @IsTest
+    static void testGetHandlerName() {
+        System.assertEquals('TestHandler', handler.getHandlerName(), 'handler name should match class name');
+    }
+
+    // test virtual methods
+
+    @IsTest
+    static void testVirtualMethods() {
+        TriggerHandler h = new TriggerHandler();
+        h.beforeInsert();
+        h.beforeUpdate();
+        h.beforeDelete();
+        h.afterInsert();
+        h.afterUpdate();
+        h.afterDelete();
+        h.afterUndelete();
+    }
+
+    /***************************************
+     * testing utilities
+     ***************************************/
+
+    private static void resetTest() {
+        lastMethodCalled = null;
+    }
+
+    // modes for testing
+
+    private static void beforeInsertMode() {
+        handler.setTriggerContext('before insert', true);
+    }
+
+    private static void beforeUpdateMode() {
+        handler.setTriggerContext('before update', true);
+    }
+
+    private static void beforeDeleteMode() {
+        handler.setTriggerContext('before delete', true);
+    }
+
+    private static void afterInsertMode() {
+        handler.setTriggerContext('after insert', true);
+    }
+
+    private static void afterUpdateMode() {
+        handler.setTriggerContext('after update', true);
+    }
+
+    private static void afterDeleteMode() {
+        handler.setTriggerContext('after delete', true);
+    }
+
+    private static void afterUndeleteMode() {
+        handler.setTriggerContext('after undelete', true);
+    }
+
+    // test implementation of the TriggerHandler
+
+    private class TestHandler extends TriggerHandler {
+
+        public override void beforeInsert() {
+            TriggerHandler_Test.lastMethodCalled = 'beforeInsert';
+        }
+
+        public override void  beforeUpdate() {
+            TriggerHandler_Test.lastMethodCalled = 'beforeUpdate';
+        }
+
+        public override void beforeDelete() {
+            TriggerHandler_Test.lastMethodCalled = 'beforeDelete';
+        }
+
+        public override void afterInsert() {
+            TriggerHandler_Test.lastMethodCalled = 'afterInsert';
+        }
+
+        public override void afterUpdate() {
+            TriggerHandler_Test.lastMethodCalled = 'afterUpdate';
+        }
+
+        public override void afterDelete() {
+            TriggerHandler_Test.lastMethodCalled = 'afterDelete';
+        }
+
+        public override void afterUndelete() {
+            TriggerHandler_Test.lastMethodCalled = 'afterUndelete';
+        }
+    }
 }

--- a/src/classes/TriggerHandler_Test.cls
+++ b/src/classes/TriggerHandler_Test.cls
@@ -160,8 +160,15 @@ private class TriggerHandler_Test {
         handler.run();
         handler.run();
 
+        Integer loopCount = TriggerHandler.getLoopCount('TestHandler');
+        System.assertEquals(2, loopCount, 'the framework should have recorded the loop count for the handler');
+
+        loopCount = TriggerHandler.getLoopCount('AnotherHandler');
+        System.assertEquals(0, loopCount, 'the framework should return 0 since the specified handler wasn\'t fired');
+
         // clear the tests
         resetTest();
+
 
         try {
             // try running it. This should exceed the limit.

--- a/src/classes/TriggerHandler_Test.cls
+++ b/src/classes/TriggerHandler_Test.cls
@@ -93,6 +93,17 @@ private class TriggerHandler_Test {
     System.assertEquals(true, TriggerHandler.isBypassed('TestHandler'), 'test handler should be bypassed');
     resetTest();
 
+    // test multiple bypasses and bypass clear
+    TriggerHandler.bypass(new List<String>{'FirstHandler', 'SecondHandler'});
+    handler.run();
+    System.assertEquals(null, lastMethodCalled, 'last method should be null when bypassed');
+    System.assertEquals(true, TriggerHandler.isBypassed('FirstHandler'), 'first test handler should be bypassed');
+    System.assertEquals(true, TriggerHandler.isBypassed('SecondHandler'), 'second test handler should be bypassed');
+    TriggerHandler.clearBypass(new List<String>{'FirstHandler', 'SecondHandler'});
+    System.assertEquals(false, TriggerHandler.isBypassed('FirstHandler'), 'first test handler should not be bypassed');
+    System.assertEquals(false, TriggerHandler.isBypassed('SecondHandler'), 'second test handler should not be bypassed');
+    resetTest();
+
     // clear that bypass and run handler
     TriggerHandler.clearBypass('TestHandler');
     handler.run();


### PR DESCRIPTION
I've found this to be useful on certain tests when I need to bypass an object handler and its children (like Account and Opportunity) on the same test. Less lines of code.