### PR TITLE
Reformat renatoliveira's patch

### DIFF
--- a/src/classes/TriggerHandler.cls
+++ b/src/classes/TriggerHandler.cls
@@ -34,7 +34,9 @@ public virtual class TriggerHandler {
   // main method that will be called during execution
   public void run() {
 
-    if(!validateRun()) return;
+    if(!validateRun()) {
+      return;
+    }
 
     addToLoopCount();
 
@@ -83,15 +85,15 @@ public virtual class TriggerHandler {
    ***************************************/
 
   public static void bypass(String handlerName) {
-    bypassedHandlers.add(handlerName);
+    TriggerHandler.bypassedHandlers.add(handlerName);
   }
 
   public static void bypass(List<String> handlersNames) {
-    bypassedHandlers.addAll(handlersNames);
+    TriggerHandler.bypassedHandlers.addAll(handlersNames);
   }
 
   public static void bypass(Type handlerType) {
-    bypass(handlerType.getName());
+    TriggerHandler.bypass(handlerType.getName());
   }
 
   public static void bypassAll() {
@@ -99,31 +101,31 @@ public virtual class TriggerHandler {
   }
 
   public static void clearBypass(String handlerName) {
-    bypassedHandlers.remove(handlerName);
+    TriggerHandler.bypassedHandlers.remove(handlerName);
   }
 
   public static void clearBypass(Type handlerType) {
-    clearBypass(handlerType.getName());
+    TriggerHandler.clearBypass(handlerType.getName());
   }
 
   public static void clearBypass(List<String> handlersNames) {
-    bypassedHandlers.removeAll(handlersNames);
-  }
-
-  public static void clearGlobalBypass() {
-    globalBypass = false;
+    TriggerHandler.bypassedHandlers.removeAll(handlersNames);
   }
 
   public static Boolean isBypassed(String handlerName) {
-    return bypassedHandlers.contains(handlerName);
+    return (globalBypass || TriggerHandler.bypassedHandlers.contains(handlerName));
   }
 
   public static Boolean isBypassed(Type handlerType) {
-    return bypassedHandlers.contains(handlerType.getName());
+    return (globalBypass || TriggerHandler.bypassedHandlers.contains(handlerType.getName()));
   }
 
   public static void clearAllBypasses() {
-    bypassedHandlers.clear();
+    if(globalBypass) {
+      globalBypass = false;
+    } else {
+      TriggerHandler.bypassedHandlers.clear();
+    }
   }
 
   public static void showLimits() {
@@ -155,27 +157,26 @@ public virtual class TriggerHandler {
       this.isTriggerExecuting = true;
     }
 
-    if((Trigger.isExecuting && Trigger.isBefore && Trigger.isInsert) ||
-        (ctx != null && ctx == 'before insert')) {
-      this.context = TriggerContext.BEFORE_INSERT;
-    } else if((Trigger.isExecuting && Trigger.isBefore && Trigger.isUpdate) ||
-        (ctx != null && ctx == 'before update')){
-      this.context = TriggerContext.BEFORE_UPDATE;
-    } else if((Trigger.isExecuting && Trigger.isBefore && Trigger.isDelete) ||
-        (ctx != null && ctx == 'before delete')) {
-      this.context = TriggerContext.BEFORE_DELETE;
-    } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isInsert) ||
-        (ctx != null && ctx == 'after insert')) {
-      this.context = TriggerContext.AFTER_INSERT;
-    } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isUpdate) ||
-        (ctx != null && ctx == 'after update')) {
-      this.context = TriggerContext.AFTER_UPDATE;
-    } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isDelete) ||
-        (ctx != null && ctx == 'after delete')) {
-      this.context = TriggerContext.AFTER_DELETE;
-    } else if((Trigger.isExecuting && Trigger.isAfter && Trigger.isUndelete) ||
-        (ctx != null && ctx == 'after undelete')) {
-      this.context = TriggerContext.AFTER_UNDELETE;
+    if(Trigger.isExecuting) {
+      if(Trigger.isBefore) {
+        if (Trigger.IsInsert || (ctx != null && ctx == 'before insert')) {
+          this.context = TriggerContext.BEFORE_INSERT;
+        } else if (Trigger.IsUpdate || (ctx != null && ctx == 'before update')) {
+          this.context = TriggerContext.BEFORE_UPDATE;
+        } else if (Trigger.IsDelete || (ctx != null && ctx == 'before delete')) {
+          this.context = TriggerContext.BEFORE_DELETE;
+        }
+      } else if(Trigger.isAfter) {
+        if (Trigger.IsInsert || (ctx != null && ctx == 'after insert')) {
+          this.context = TriggerContext.AFTER_INSERT;
+        } else if (Trigger.IsUpdate || (ctx != null && ctx == 'after  update')) {
+          this.context = TriggerContext.AFTER_UPDATE;
+        } else if (Trigger.IsDelete || (ctx != null && ctx == 'after delete')) {
+          this.context = TriggerContext.AFTER_DELETE;
+        } else if (Trigger.IsUndelete || (ctx != null && ctx == 'after undelete')) {
+          this.context = TriggerContext.AFTER_UNDELETE;
+        }
+      }
     }
   }
 

--- a/src/classes/TriggerHandler.cls
+++ b/src/classes/TriggerHandler.cls
@@ -3,6 +3,8 @@ public virtual class TriggerHandler {
   // static map of handlername, times run() was invoked
   private static Map<String, LoopCount> loopCountMap;
   private static Set<String> bypassedHandlers;
+  @TestVisible private static Boolean globalBypass;
+  @TestVisible private static Boolean showLimits;
 
   // the current context of the trigger, overridable in tests
   @TestVisible
@@ -16,8 +18,10 @@ public virtual class TriggerHandler {
   static {
     loopCountMap = new Map<String, LoopCount>();
     bypassedHandlers = new Set<String>();
+    globalBypass = false;
+    showLimits = false;
   }
-  
+
   // constructor
   public TriggerHandler() {
     this.setTriggerContext();
@@ -51,6 +55,14 @@ public virtual class TriggerHandler {
       this.afterUndelete();
     }
 
+    if(showLimits) {
+      System.debug(LoggingLevel.DEBUG, String.format('{0} on {1} ({2}/{3})', new List<String>{
+        this.context+'',
+        getHandlerName(),
+        Limits.getQueries()+'',
+        Limits.getLimitQueries()+''
+      }));
+    }
   }
 
   public void setMaxLoopCount(Integer max) {
@@ -71,19 +83,58 @@ public virtual class TriggerHandler {
    ***************************************/
 
   public static void bypass(String handlerName) {
-    TriggerHandler.bypassedHandlers.add(handlerName);
+    bypassedHandlers.add(handlerName);
+  }
+
+  public static void bypass(List<String> handlersNames) {
+    bypassedHandlers.addAll(handlersNames);
+  }
+
+  public static void bypass(Type handlerType) {
+    bypass(handlerType.getName());
+  }
+
+  public static void bypassAll() {
+    globalBypass = true;
   }
 
   public static void clearBypass(String handlerName) {
-    TriggerHandler.bypassedHandlers.remove(handlerName);
+    bypassedHandlers.remove(handlerName);
+  }
+
+  public static void clearBypass(Type handlerType) {
+    clearBypass(handlerType.getName());
+  }
+
+  public static void clearBypass(List<String> handlersNames) {
+    bypassedHandlers.removeAll(handlersNames);
+  }
+
+  public static void clearGlobalBypass() {
+    globalBypass = false;
   }
 
   public static Boolean isBypassed(String handlerName) {
-    return TriggerHandler.bypassedHandlers.contains(handlerName);
+    return bypassedHandlers.contains(handlerName);
+  }
+
+  public static Boolean isBypassed(Type handlerType) {
+    return bypassedHandlers.contains(handlerType.getName());
   }
 
   public static void clearAllBypasses() {
-    TriggerHandler.bypassedHandlers.clear();
+    bypassedHandlers.clear();
+  }
+
+  public static void showLimits() {
+    showLimits = true;
+  }
+
+  public static Integer getLoopCount(String handlerName) {
+    if(TriggerHandler.loopCountMap.containsKey(handlerName)) {
+      return TriggerHandler.loopCountMap.get(handlerName).getCount();
+    }
+    return 0;
   }
 
   /***************************************
@@ -103,7 +154,7 @@ public virtual class TriggerHandler {
     } else {
       this.isTriggerExecuting = true;
     }
-    
+
     if((Trigger.isExecuting && Trigger.isBefore && Trigger.isInsert) ||
         (ctx != null && ctx == 'before insert')) {
       this.context = TriggerContext.BEFORE_INSERT;
@@ -147,7 +198,7 @@ public virtual class TriggerHandler {
     if(!this.isTriggerExecuting || this.context == null) {
       throw new TriggerHandlerException('Trigger handler called outside of Trigger execution');
     }
-    if(TriggerHandler.bypassedHandlers.contains(getHandlerName())) {
+    if(globalBypass || TriggerHandler.bypassedHandlers.contains(getHandlerName())) {
       return false;
     }
     return true;


### PR DESCRIPTION
This started out as a reformatted PR#13 per the request from @kevinohara80 there. (I asked there if renatoliveira was OK with me submitting a reformatted version, and he said he was). I added the following changes:
1. Restored the clearAllBypasses method, and made it work for either manually bypassed handlers or a globalBypass.
2. Removed the new clearGlobalBypass method since #1 handles it as well.
3. Changed the isBypassed methods to return true if a globalBypass was in effect.
4. Restructured the ifs in setTriggerContext to make the block a bit more efficient.
5. Updated the README to include examples of bypassing a list and using globalBypass().