### PR TITLE
Fix typos in README.md for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ trigger OpportunityTrigger on Opportunity (before insert, before update) {
 
 ### Max Loop Count
 
-To prevent recursion, you can set a max loop count for Trigger Handler. If this max is exceeded, and exception will be thrown. A great use case is when you want to ensure that your trigger runs once and only once within a single execution. Example:
+To prevent recursion, you can set a max loop count for Trigger Handler. If this max is exceeded, an exception will be thrown. A great use case is when you want to ensure that your trigger runs once and only once within a single execution. Example:
 
 ```java
 public class OpportunityTriggerHandler extends TriggerHandler {
@@ -94,7 +94,7 @@ public class OpportunityTriggerHandler extends TriggerHandler {
 
 ### Bypass API
 
-What if you want to tell other trigger handlers to halt execution? That's easy with the bypass api:
+What if you want to tell other trigger handlers to halt execution? That's easy with the bypass API:
 
 ```java
 public class OpportunityTriggerHandler extends TriggerHandler {


### PR DESCRIPTION
Just some minor fixes on grammatical errors I found while I was reading the docs to understand it better. Because I was selected to join a company as a Trainee Salesforce Developer and my manager asked me to give it a reading to acclimate myselft with the framework they use.